### PR TITLE
fix(slider): prevent slider range thumb from glitching when value changes during drag

### DIFF
--- a/src/dev-app/slider/slider-demo.html
+++ b/src/dev-app/slider/slider-demo.html
@@ -186,4 +186,17 @@
       <button matButton="elevated" [color]="colorModel" (click)="openDialog()">Open dialog</button>
     </div>
   </mat-tab>
+
+  <mat-tab label="Signal forms issue 33008">
+    <div style="margin: 20px;">
+      <p>Reproduction of issue #33008 where slider range thumb glitches when signal form emits value change</p>
+      <mat-slider [discrete]="discrete" [showTickMarks]="showTickMarks" [color]="colorModel">
+        <input matSliderStartThumb [value]="issueFormStartControl.value" (input)="issueFormStartControl.setValue($any($event.target).value)" />
+        <input matSliderEndThumb [value]="issueFormEndControl.value" (input)="issueFormEndControl.setValue($any($event.target).value)" />
+      </mat-slider>
+      <div>Start: {{ issueFormStartControl.value }}</div>
+      <div>End: {{ issueFormEndControl.value }}</div>
+    </div>
+  </mat-tab>
+
 </mat-tab-group>

--- a/src/dev-app/slider/slider-demo.html
+++ b/src/dev-app/slider/slider-demo.html
@@ -191,8 +191,8 @@
     <div style="margin: 20px;">
       <p>Reproduction of issue #33008 where slider range thumb glitches when signal form emits value change</p>
       <mat-slider [discrete]="discrete" [showTickMarks]="showTickMarks" [color]="colorModel">
-        <input matSliderStartThumb [value]="issueFormStartControl.value" (input)="issueFormStartControl.setValue($any($event.target).value)" />
-        <input matSliderEndThumb [value]="issueFormEndControl.value" (input)="issueFormEndControl.setValue($any($event.target).value)" />
+        <input matSliderStartThumb [formControl]="issueFormStartControl" />
+        <input matSliderEndThumb [formControl]="issueFormEndControl" />
       </mat-slider>
       <div>Start: {{ issueFormStartControl.value }}</div>
       <div>End: {{ issueFormEndControl.value }}</div>

--- a/src/dev-app/slider/slider-demo.ts
+++ b/src/dev-app/slider/slider-demo.ts
@@ -57,6 +57,9 @@ export class SliderDemo {
   stepModel = 0;
   disabledModel = false;
 
+  issueFormStartControl = new FormControl('30', {nonNullable: true});
+  issueFormEndControl = new FormControl('70', {nonNullable: true});
+
   control = new FormControl('0');
 
   updateValue(input: EventTarget | null): void {

--- a/src/material/slider/slider-input.ts
+++ b/src/material/slider/slider-input.ts
@@ -814,8 +814,10 @@ export class MatSliderRangeThumb extends MatSliderThumb implements _MatSliderRan
   override writeValue(value: any): void {
     if (this._isControlInitialized || value !== null) {
       this.value = value;
-      this._updateWidthInactive();
-      this._updateSibling();
+      if (!this._isActive) {
+        this._updateWidthInactive();
+        this._updateSibling();
+      }
     }
   }
 

--- a/src/material/slider/slider.spec.ts
+++ b/src/material/slider/slider.spec.ts
@@ -1413,6 +1413,36 @@ describe('MatSlider', () => {
       expect(fixture.componentInstance.startInputControl.value).toBe(20);
     });
 
+
+    it('should not update inactive styles when value changes while dragging', async () => {
+      // Set initial values
+      fixture.componentInstance.startInputControl.setValue(10);
+      fixture.componentInstance.endInputControl.setValue(90);
+      fixture.detectChanges();
+
+      const startInputNode = slider._getInput(_MatThumb.START) as MatSliderRangeThumb;
+      const hostElement = startInputNode._hostElement;
+
+      // Simulate pointer down to make it active
+      dispatchPointerEvent(hostElement, 'pointerdown', 10, 0);
+      fixture.detectChanges();
+
+      expect(startInputNode._isActive).toBe(true);
+
+      // Save the style before value update
+      const activeStyle = hostElement.style.padding;
+
+      // Update value through form control
+      fixture.componentInstance.startInputControl.setValue(20);
+      fixture.detectChanges();
+
+      // Ensure that _updateWidthInactive was not called (which would set padding to 0px)
+      expect(hostElement.style.padding).toBe(activeStyle);
+
+      dispatchPointerEvent(hostElement, 'pointerup', 20, 0);
+      fixture.detectChanges();
+    });
+
     it('should update the end input control on slide', async () => {
       expect(fixture.componentInstance.endInputControl.value).toBe(100);
       await slideToValue(slider, endInput, 80);


### PR DESCRIPTION
Fixes a visual glitch in `MatSliderRangeThumb` where the slider would jump/reset when its bound form control (like signal forms) emits a value change while dragging is still in progress.

Changes:
- In `slider-input.ts`, update `writeValue` of `MatSliderRangeThumb` to only invoke `_updateWidthInactive` and `_updateSibling` if `!this._isActive`.
- Added a test in `slider.spec.ts` (`should not update inactive styles when value changes while dragging`) to assert this logic.

---
*PR created automatically by Jules for task [16273993297110693208](https://jules.google.com/task/16273993297110693208) started by @wagnermaciel*